### PR TITLE
Check need for interpolation to compare results 

### DIFF
--- a/swmmanywhere/misc/debug_interpolation.py
+++ b/swmmanywhere/misc/debug_interpolation.py
@@ -49,3 +49,5 @@ df = pd.merge(syn_data,
                 how='outer').sort_index()
 
 print(str(df.dropna().shape[0] / df.shape[0] * 100))
+# We find that syn_data and real_data perfect align 0.2% of the time. Thus, 
+# the interpolation in align_calc_nse is certainly needed.


### PR DESCRIPTION
# Description

@cheginit I've pulled out a sample synthetic results timeseries and compared with a real one. We see that the time indices perfectly align less than 1% of the time, so I think we are going to have to interpolate to make NSE comparisons.

Fixes #76 