### PR TITLE
Set up codecov workflow and badges

### DIFF
--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -33,9 +33,9 @@ jobs:
       run: pytest
 
     - name: Upload coverage to Codecov
-      if: success() && (github.event_name == 'push' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')
+      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')
       uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Run tests
       run: pytest --junitxml=junit/pytest.xml \
-        --cov=swmmanywhere \
+        --cov=src/swmmanywhere \
         --cov-branch \
         --cov-report=xml
 
@@ -39,7 +39,6 @@ jobs:
       if: success() && (github.event_name == 'push' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')
       uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
-        files: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true

--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -30,10 +30,7 @@ jobs:
       run: pip install .[dev]
 
     - name: Run tests
-      run: pytest --junitxml=junit/pytest.xml \
-        --cov=src/swmmanywhere \
-        --cov-branch \
-        --cov-report=xml
+      run: pytest
 
     - name: Upload coverage to Codecov
       if: success() && (github.event_name == 'push' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')

--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -25,7 +25,21 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: pip install .[dev]
+
     - name: Run tests
-      run: pytest
+      run: pytest --junitxml=junit/pytest.xml \
+        --cov=swmmanywhere \
+        --cov-branch \
+        --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      if: success() && (github.event_name == 'push' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false
+        files: ./coverage.xml
+        verbose: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI version shields.io](https://img.shields.io/pypi/v/swmmanywhere.svg)](https://pypi.python.org/pypi/swmmanywhere/)
 [![Test and build](https://github.com/ImperialCollegeLondon/SWMManywhere/actions/workflows/ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/SWMManywhere/actions/workflows/ci.yml)
 [![DOI](https://zenodo.org/badge/741903266.svg)](https://zenodo.org/doi/10.5281/zenodo.13837741)
+[![codecov](https://codecov.io/gh/ImperialCollegeLondon/SWMManywhere/graph/badge.svg)](https://codecov.io/gh/ImperialCollegeLondon/SWMManywhere)
 <!-- markdown-link-check-enable -->
 
 SWMManywhere is a tool to synthesise urban drainage network models (UDMs) using

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SWMManywhere: Synthesise Urban Drainage Network Models Anywhere in the World
 
 <!-- markdown-link-check-disable -->
+[![PyPI version shields.io](https://img.shields.io/pypi/v/swmmanywhere.svg)](https://pypi.python.org/pypi/swmmanywhere/)
 [![Test and build](https://github.com/ImperialCollegeLondon/SWMManywhere/actions/workflows/ci.yml/badge.svg)](https://github.com/ImperialCollegeLondon/SWMManywhere/actions/workflows/ci.yml)
 [![DOI](https://zenodo.org/badge/741903266.svg)](https://zenodo.org/doi/10.5281/zenodo.13837741)
 <!-- markdown-link-check-enable -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,9 +17,6 @@ plugins:
   - mkdocs-jupyter: 
       execute: false
   - search
-  - coverage:
-      page_name: coverage  # default
-      html_report_dir: htmlcov  # default
   - include-markdown
 
 repo_url: https://github.com/ImperialCollegeLondon/SWMManywhere

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,4 +61,4 @@ nav:
     - Post processing: reference-post-processing.md
     - Preprocessing: reference-preprocessing.md
     - Config definitions: reference-defs.md
-  - Coverage report: coverage.md
+  - Coverage report: https://app.codecov.io/gh/ImperialCollegeLondon/SWMManywhere

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.doc = [
   "mkdocs",
-  "mkdocs-coverage",
   "mkdocs-include-markdown-plugin",
   "mkdocs-jupyter",
   "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ skip = "src/swmmanywhere/defs/iso_converter.yml,*.inp"
 ignore-words-list = "gage,gages"
 
 [tool.pytest.ini_options]
-addopts = "-v --cov=src/swmmanywhere --cov-report=html --doctest-modules --ignore=src/swmmanywhere/logging.py"
+addopts = "-v --cov=src/swmmanywhere --cov-report=xml --doctest-modules --ignore=src/swmmanywhere/logging.py"
 markers = [
   "downloads: mark a test as requiring downloads",
 ]


### PR DESCRIPTION
# Description

Adds a step to the CI workflow to upload the coverage report to codecov, and link this page from the documentation.

NOTE: the workflow is currently failing, but we believe it will only work once it has been merged to main

This replaces a half-implemented workflow using the [mkdocs-coverage](https://pypi.org/project/mkdocs-coverage/) package which would be considerably more effort to set up properly. I also needed to change the coverage report from html to xml to get it working with codecov.

Also adds badges for codecov and PyPI to the readme

Fixes #287 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
