### PR TITLE
Notebook import error

### DIFF
--- a/docs/notebooks/extended_demo.py
+++ b/docs/notebooks/extended_demo.py
@@ -1,0 +1,2 @@
+"""Force a strange error."""
+import swmmanywhere

--- a/docs/notebooks/extended_demo.py
+++ b/docs/notebooks/extended_demo.py
@@ -1,2 +1,1 @@
 """Force a strange error."""
-import swmmanywhere


### PR DESCRIPTION
# Description

Seems that simply importing `swmmanywhere` from the `docs` directory causes a range of collection errors during testing.