### PR TITLE
Instruct to install in editable mode in CONTRIBUTING docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,7 +64,7 @@ the conflicts. To install the development dependencies and then `SWMManywhere`
 in development mode, run:
 
 ```bash
-pip install .[dev,doc]
+pip install -e .[dev,doc]
 ```
 
 ## Quality assurance and linting


### PR DESCRIPTION
# Description

Package should be installed in editable mode for tests to pass. This is already done in CI and was in the old (currently published) version of the docs, but not the most up to date version of the docs.

Fixes #330 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
