### PR TITLE
Set default python version to 3.12 in tests

### DIFF
--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -12,7 +12,7 @@ on:
         type: string
       python-version:
         description: 'Python version'
-        default: '["3.10"]'
+        default: '["3.12"]'
         type: string
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
       run: pytest
 
     - name: Upload coverage to Codecov
-      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10')
+      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12')
       uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
# Description

This is to test if issue #329 can be reproduced

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
