### PR TITLE
Get subset of building data, not all.

### DIFF
--- a/src/swmmanywhere/prepare_data.py
+++ b/src/swmmanywhere/prepare_data.py
@@ -92,7 +92,7 @@ def _record_batch_reader(bbox: tuple[float, float, float, float]) -> RecordBatch
 
 def download_buildings_bbox(
     file_address: Path, bbox: tuple[float, float, float, float]
-):
+) -> None:
     """Retrieve building data in bbox from Overture Maps to file.
 
     This function is based on

--- a/src/swmmanywhere/preprocessing.py
+++ b/src/swmmanywhere/preprocessing.py
@@ -78,23 +78,14 @@ def prepare_elevation(
 def prepare_building(
     bbox: tuple[float, float, float, float], addresses: FilePaths, target_crs: str
 ):
-    """Download, trim and reproject building data."""
+    """Download and reproject building data."""
     if addresses.bbox_paths.building.exists():
         return
 
-    if not addresses.project_paths.national_building.exists():
-        logger.info(
-            f"""downloading buildings to 
-                    {addresses.project_paths.national_building}"""
-        )
-        prepare_data.download_buildings(
-            addresses.project_paths.national_building, bbox[0], bbox[1]
-        )
+    logger.info(f"downloading buildings to {addresses.bbox_paths.building}")
+    prepare_data.download_buildings_bbox(addresses.bbox_paths.building, bbox)
 
-    logger.info(f"trimming buildings to {addresses.bbox_paths.building}")
-    national_buildings = gpd.read_parquet(addresses.project_paths.national_building)
-    buildings = national_buildings.cx[bbox[0] : bbox[2], bbox[1] : bbox[3]]  # type: ignore
-
+    buildings = gpd.read_parquet(addresses.bbox_paths.building)
     buildings = buildings.to_crs(target_crs)
     write_df(buildings, addresses.bbox_paths.building)
 

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -80,7 +80,7 @@ def test_building_bbox_downloader_download():
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_fid = Path(temp_dir) / "temp.parquet"
         # Download
-        response = downloaders.download_buildings_bbox(temp_fid, bbox)
+        downloaders.download_buildings_bbox(temp_fid, bbox)
 
         # Check file exists
         assert temp_fid.exists(), "Buildings data file not found after download."

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -72,6 +72,7 @@ def test_building_downloader_download():
         # Make sure has some rows
         assert gdf.shape[0] > 0
 
+
 @pytest.mark.downloads
 def test_building_bbox_downloader_download():
     """Check buildings are downloaded."""
@@ -90,6 +91,7 @@ def test_building_bbox_downloader_download():
 
         # Make sure has some rows
         assert gdf.shape[0] > 0
+
 
 @pytest.mark.downloads
 def test_street_downloader_download():

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -72,6 +72,24 @@ def test_building_downloader_download():
         # Make sure has some rows
         assert gdf.shape[0] > 0
 
+@pytest.mark.downloads
+def test_building_bbox_downloader_download():
+    """Check buildings are downloaded."""
+    # Coordinates for small country (VAT)
+    bbox = (-0.17929, 51.49638, -0.17383, 51.49846)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_fid = Path(temp_dir) / "temp.parquet"
+        # Download
+        response = downloaders.download_buildings_bbox(temp_fid, bbox)
+
+        # Check file exists
+        assert temp_fid.exists(), "Buildings data file not found after download."
+
+        # Load data
+        gdf = gpd.read_parquet(temp_fid)
+
+        # Make sure has some rows
+        assert gdf.shape[0] > 0
 
 @pytest.mark.downloads
 def test_street_downloader_download():


### PR DESCRIPTION
# Description

This PR adds code for interfacing with Overture for building data, allowing the download of only a subset of data (constrained by a given bounding box), instead of the entire dataset for the country. The downloaded `building.geoparquet` file is significantly smaller as a result.

I left the original national downloader in for not, in case it's still useful.

I have not tested this yet, beyond peering inside the geoparaquet file (I run Linux, so can't run the GUI). Please could you confirm?

Some things to note:
* There are two endpoints: S3 or Azure (I arbitrarily chose S3)
* S3 region is fixed, as only `us-west-2` is available
* I haven't yet figured out the `version` parameter, how to auto pick latest, or if that's even possible without hacking
* I'm not so familiar with the data formats, so extra optimisation is perhaps possible.

Fixes #133 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
