### PR TITLE
codecov issue on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/ci_template.yml
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
     with:
       os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
       python-version: '["3.10", "3.11", "3.12"]'


### PR DESCRIPTION
# Description

Looks like `publish.yml` is crashing on [release](https://github.com/ImperialCollegeLondon/SWMManywhere/actions/runs/11596632689/workflow) because it doesn't have `codecov` secret - would this fix it?

Also there's that thing we need to do for releases that failed in some way - but I can't remember what it's called


Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
