### PR TITLE
Reduce outfall diameter

### DIFF
--- a/src/swmmanywhere/post_processing.py
+++ b/src/swmmanywhere/post_processing.py
@@ -81,7 +81,7 @@ def synthetic_write(addresses: FilePaths):
     new_edges["u"] = outfalls["id"].str.replace("_outfall", "").values
     new_edges["v"] = outfalls["id"].values
     new_edges["id"] = [f"{u}-{v}" for u, v in zip(new_edges["u"], new_edges["v"])]
-    new_edges["diameter"] = 15  # TODO .. big pipe to enable all outfall...
+    new_edges["diameter"] = edges.diameter.max()
     new_edges["length"] = (50**2 + 50**2) ** 0.5
     new_edges["roughness"] = 0.01
     new_edges["capacity"] = 1e10

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -124,7 +124,7 @@ def generate_data_dict():
             "length": [1, (50**2 + 50**2) ** 0.5],
             "roughness": [0.01, 0.01],
             "shape_swmm": ["CIRCULAR", "CIRCULAR"],
-            "diameter": [1, 15],
+            "diameter": [1, 1],
             "capacity": [1e10, 1e10],
         }
     )


### PR DESCRIPTION
# Description

The comically large diameter outfall pipe seems to contribute to numerical instabilities. This is a simple solution to that. There could be some complexity if you have a network with two distinct branches which only join at the outfall, though that is a more complicated solution. I think any more complicated solution would best be addressed as part of #84 .

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
