### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,7 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
+        verbose: true
 
   publish-PyPI:
     needs: publish-TestPyPI


### PR DESCRIPTION
This PR simply adds more verbosity to the action that pushes a new version of SWMManywhere to TestPyPI, to try to figure out what's going on. Once this is merged, we will need to scrap the current 0.1.13 release and create a new one to trigger the publishing workflow. 