### PR TITLE
Design graphfunction refactor

### DIFF
--- a/src/swmmanywhere/graphfcns/design_graphfcns.py
+++ b/src/swmmanywhere/graphfcns/design_graphfcns.py
@@ -20,7 +20,7 @@ def get_designs(hydraulic_design: parameters.HydraulicDesign) -> product:
 
     This function generates a grid of designs for the pipe based on the
     diameters and depths specified in the hydraulic design parameters. It
-    returns a numpy array of the designs.
+    returns an iterable product of the designs.
 
     Args:
         hydraulic_design (parameters.HydraulicDesign): A HydraulicDesign parameter
@@ -32,8 +32,10 @@ def get_designs(hydraulic_design: parameters.HydraulicDesign) -> product:
     return product(
         hydraulic_design.diameters,
         np.linspace(
-            hydraulic_design.min_depth, hydraulic_design.max_depth, 10
-        ),  # TODO should 10 be a param?
+            hydraulic_design.min_depth,
+            hydraulic_design.max_depth,
+            hydraulic_design.depth_nbins,
+        ),
     )
 
 
@@ -229,7 +231,7 @@ def process_successors(
     node: Hashable,
     surface_elevations: dict[Hashable, float],
     chamber_floor: dict[Hashable, float],
-    edge_designs: dict[tuple[Hashable, Hashable, int], dict[Hashable, float]],
+    edge_designs: dict[str, dict[tuple[Hashable, Hashable, int], float]],
     hydraulic_design: parameters.HydraulicDesign,
 ) -> None:
     """Process the successors of a node.
@@ -237,8 +239,8 @@ def process_successors(
     This function processes the successors of a node. It designs a pipe to the
     downstream node and sets the diameter and downstream invert level of the
     pipe. It also sets the downstream invert level of the downstream node. It
-    returns None but modifies the hydraulic_design.edge_design_parameters and node
-    chamber_floor dictionaries.
+    returns None but modifies the hydraulic_design.edge_design_parameters entries inside
+    edge_designs and node chamber_floor dictionaries.
 
     Args:
         G (nx.Graph): A graph
@@ -247,7 +249,8 @@ def process_successors(
             node
         chamber_floor (dict): A dictionary of chamber floor elevations keyed by
             node
-        edge_designs (dict): A dictionary of pipe designs keyed by edge
+        edge_designs (dict): A dictionary of pipe designs keyed by parameter and then
+            edge
         hydraulic_design (parameters.HydraulicDesign): A HydraulicDesign parameter
             object
     """
@@ -325,7 +328,7 @@ class pipe_by_pipe(
         topological_order = list(nx.topological_sort(G))
         chamber_floor = {}
 
-        edge_designs: dict[tuple[Hashable, Hashable, int], dict[Hashable, float]] = {
+        edge_designs: dict[str, dict[tuple[Hashable, Hashable, int], float]] = {
             parameter: {} for parameter in hydraulic_design.edge_design_parameters
         }
 

--- a/src/swmmanywhere/graphfcns/design_graphfcns.py
+++ b/src/swmmanywhere/graphfcns/design_graphfcns.py
@@ -24,7 +24,7 @@ def get_designs(hydraulic_design: parameters.HydraulicDesign) -> np.ndarray:
 
     Args:
         hydraulic_design (parameters.HydraulicDesign): A HydraulicDesign parameter
-            object  
+            object
 
     Returns:
         designs (np.ndarray): A numpy array of the designs for the pipe
@@ -36,6 +36,7 @@ def get_designs(hydraulic_design: parameters.HydraulicDesign) -> np.ndarray:
         ),  # TODO should 10 be a param?
     )
 
+
 def evaluate_design(
     ds_elevation: float,
     chamber_floor: float,
@@ -44,7 +45,7 @@ def evaluate_design(
     Q: float,
     diam: float,
     depth: float,
-    ):
+):
     """Evaluate the design of a pipe.
 
     This function evaluates the design of a pipe by calculating the cost,
@@ -106,31 +107,31 @@ def evaluate_design(
     """
     slope = (chamber_floor - (ds_elevation - depth)) / edge_length
     return {
-                "diam": diam,
-                "depth": depth,
-                "slope": slope,
-                "v": v,
-                "fr": filling_ratio,
-                # 'tau' : shear_stress,
-                "cost": cost,
-                "v_feasibility": v_feasibility,
-                "fr_feasibility": fr_feasibility,
-                "surcharge_feasibility": surcharge_feasibility,
-                # 'shear_feasibility' : shear_feasibility
-            }
+        "diam": diam,
+        "depth": depth,
+        "slope": slope,
+        "v": v,
+        "fr": filling_ratio,
+        # 'tau' : shear_stress,
+        "cost": cost,
+        "v_feasibility": v_feasibility,
+        "fr_feasibility": fr_feasibility,
+        "surcharge_feasibility": surcharge_feasibility,
+        # 'shear_feasibility' : shear_feasibility
+    }
 
 
 def select_design(pipes_df: pd.DataFrame) -> tuple[float, float, float]:
     """Select the ideal design from the dataframe.
-    
+
     This function selects the ideal design from the dataframe by sorting the
     dataframe based on the feasibility parameters and cost. It returns the
     diameter, depth, and cost of the ideal design.
-    
+
     Args:
         pipes_df (pd.DataFrame): A dataframe containing the designs and their
             parameters
-    
+
     Returns:
         tuple: A tuple containing the diameter, depth, and cost of the ideal
             design
@@ -150,7 +151,7 @@ def select_design(pipes_df: pd.DataFrame) -> tuple[float, float, float]:
         return ideal_pipe.diam, ideal_pipe.depth, ideal_pipe.cost
     else:
         raise ValueError("No non nan pipes designed. Shouldn't happen.")
-        
+
 
 def design_pipe(
     ds_elevation: float,
@@ -221,8 +222,9 @@ def calculate_flow(G: nx.Graph, node: Hashable, design_precipitation) -> float:
     anc = nx.ancestors(G, node).union([node])
     tot = sum([G.nodes[anc_node]["contributing_area"] for anc_node in anc])
     M3_PER_HR_TO_M3_PER_S = 1 / 60 / 60
-    
+
     return tot * design_precipitation * M3_PER_HR_TO_M3_PER_S
+
 
 def process_successors(
     G: nx.Graph,

--- a/src/swmmanywhere/graphfcns/design_graphfcns.py
+++ b/src/swmmanywhere/graphfcns/design_graphfcns.py
@@ -157,7 +157,7 @@ def select_design(pipes_df: pd.DataFrame) -> dict[Hashable, float]:
     """
     if pipes_df.shape[0] <= 0:
         raise ValueError("No non nan pipes designed. Shouldn't happen.")
-    
+
     ideal_pipe = pipes_df.sort_values(
         by=[
             "surcharge_feasibility",
@@ -169,9 +169,8 @@ def select_design(pipes_df: pd.DataFrame) -> dict[Hashable, float]:
         ],
         ascending=True,
     ).iloc[0]
-    
+
     return ideal_pipe.to_dict()
-        
 
 
 def design_pipe(

--- a/src/swmmanywhere/graphfcns/design_graphfcns.py
+++ b/src/swmmanywhere/graphfcns/design_graphfcns.py
@@ -237,7 +237,8 @@ def process_successors(
     This function processes the successors of a node. It designs a pipe to the
     downstream node and sets the diameter and downstream invert level of the
     pipe. It also sets the downstream invert level of the downstream node. It
-    returns None but modifies the edge_diams and chamber_floor dictionaries.
+    returns None but modifies the hydraulic_design.edge_design_parameters and node
+    chamber_floor dictionaries.
 
     Args:
         G (nx.Graph): A graph

--- a/src/swmmanywhere/graphfcns/design_graphfcns.py
+++ b/src/swmmanywhere/graphfcns/design_graphfcns.py
@@ -15,7 +15,7 @@ from swmmanywhere.graph_utilities import BaseGraphFunction, register_graphfcn
 from swmmanywhere.logging import logger, verbose
 
 
-def get_designs(hydraulic_design: parameters.HydraulicDesign) -> np.ndarray:
+def get_designs(hydraulic_design: parameters.HydraulicDesign) -> product:
     """Get the designs for the pipe.
 
     This function generates a grid of designs for the pipe based on the
@@ -27,7 +27,7 @@ def get_designs(hydraulic_design: parameters.HydraulicDesign) -> np.ndarray:
             object
 
     Returns:
-        designs (np.ndarray): A numpy array of the designs for the pipe
+        product: An iterable product object containing the designs
     """
     return product(
         hydraulic_design.diameters,
@@ -45,7 +45,7 @@ def evaluate_design(
     Q: float,
     diam: float,
     depth: float,
-):
+) -> dict[Hashable, float]:
     """Evaluate the design of a pipe.
 
     This function evaluates the design of a pipe by calculating the cost,
@@ -61,8 +61,9 @@ def evaluate_design(
         Q (float): The flow rate
         diam (float): The diameter of the pipe
         depth (float): The depth of the pipe
+
     Returns:
-        dict: A dictionary containing the design parameters and their values
+        dict: A dictionary containing the designed pipe's parameters and values
     """
     A = np.pi * diam**2 / 4
     n = 0.012  # mannings n

--- a/src/swmmanywhere/parameters.py
+++ b/src/swmmanywhere/parameters.py
@@ -292,7 +292,13 @@ class HydraulicDesign(BaseModel):
         description="Depth of design storm in pipe by pipe method",
         unit="m",
     )
-    edge_design_parameters: list = Field(
+    depth_nbins: int = Field(
+        default=10,
+        ge=1,
+        unit="-",
+        description="Number of bins to discretise depth for in pipe by pipe method",
+    )
+    edge_design_parameters: list[str] = Field(
         default=["diameter", "cost_usd"],
         min_items=1,
         unit="-",

--- a/src/swmmanywhere/parameters.py
+++ b/src/swmmanywhere/parameters.py
@@ -292,6 +292,12 @@ class HydraulicDesign(BaseModel):
         description="Depth of design storm in pipe by pipe method",
         unit="m",
     )
+    edge_design_parameters: list = Field(
+        default=["diameter", "cost_usd"],
+        min_items=1,
+        unit="-",
+        description="Edge design parameters to consider in pipe by pipe method",
+    )
 
 
 @register_parameter_group(name="metric_evaluation")

--- a/src/swmmanywhere/parameters.py
+++ b/src/swmmanywhere/parameters.py
@@ -296,7 +296,8 @@ class HydraulicDesign(BaseModel):
         default=["diameter", "cost_usd"],
         min_items=1,
         unit="-",
-        description="Edge design parameters to consider in pipe by pipe method",
+        description="""Edge parameters calculated by the design process to retain in the
+                    graph after the pipe_by_pipe graphfcn has been applied.""",
     )
 
 


### PR DESCRIPTION
# Description

Quite a significant need to refactor `design_graphfcns`.

Existing behaviour is the same, however, two key changes have been implemented:

- Split out existing functions into more modular functions
- The information that is retained for a designed edge is now a selectable parameter, the logic being that if someone wanted to use other design information in subsequent graphfcns, they can now retain that with this parameter.
- Further, if users wanted to edit the design process, all functions have been moved to belong to the class in #423 (to be reviewed separately for simplicity).

I know I could probably go further, but hopefully is still a significant improvement over what it was.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
