### PR TITLE
Link warning

### DIFF
--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -12,7 +12,7 @@ on:
         type: string
       python-version:
         description: 'Python version'
-        default: '["3.10"]'
+        default: '["3.12"]'
         type: string
 
 jobs:

--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -12,7 +12,7 @@ on:
         type: string
       python-version:
         description: 'Python version'
-        default: '["3.12"]'
+        default: '["3.10", "3.12"]'
         type: string
 
 jobs:

--- a/src/swmmanywhere/metric_utilities.py
+++ b/src/swmmanywhere/metric_utilities.py
@@ -1064,7 +1064,7 @@ def bias_flood_depth(
     """Run the evaluated metric."""
 
     def _f(x):
-        return np.trapz(x.value, x.duration)
+        return np.trapezoid(x.value, x.duration)
 
     syn_flooding = extract_var(synthetic_results, "flooding").groupby("id").apply(_f)
     syn_area = synthetic_subs.impervious_area.sum()

--- a/src/swmmanywhere/misc/debug_derive_rc.py
+++ b/src/swmmanywhere/misc/debug_derive_rc.py
@@ -79,7 +79,7 @@ def derive_rc_alt(
     )
 
     # Store as impervious area in subcatchments
-    subcatchments["impervious_area"] = 0
+    subcatchments["impervious_area"] = 0.0
     subcatchments.loc[areas.index, "impervious_area"] = areas
     subcatchments["rc"] = (
         subcatchments["impervious_area"] / subcatchments.geometry.area * 100

--- a/src/swmmanywhere/utilities.py
+++ b/src/swmmanywhere/utilities.py
@@ -265,7 +265,7 @@ def save_graph(G: nx.Graph, fid: Path) -> None:
     # Save as JSON format (original implementation)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
-        json_data = nx.node_link_data(G)
+        json_data = nx.node_link_data(G, edges="links")
 
     with fid.open("w") as file:
         json.dump(json_data, file, default=_serialize_line_string)
@@ -285,7 +285,7 @@ def load_graph(fid: Path) -> nx.Graph:
     """
     # Load from JSON format (original implementation)
     json_data = json.loads(fid.read_text())
-    G = nx.node_link_graph(json_data, directed=True, edges="edges")
+    G = nx.node_link_graph(json_data, directed=True, edges="links")
     for u, v, data in G.edges(data=True):
         if "geometry" in data:
             geometry_coords = data["geometry"]

--- a/src/swmmanywhere/utilities.py
+++ b/src/swmmanywhere/utilities.py
@@ -285,7 +285,7 @@ def load_graph(fid: Path) -> nx.Graph:
     """
     # Load from JSON format (original implementation)
     json_data = json.loads(fid.read_text())
-    G = nx.node_link_graph(json_data, directed=True)
+    G = nx.node_link_graph(json_data, directed=True, edges="edges")
     for u, v, data in G.edges(data=True):
         if "geometry" in data:
             geometry_coords = data["geometry"]

--- a/tests/test_metric_utilities.py
+++ b/tests/test_metric_utilities.py
@@ -285,25 +285,25 @@ def test_outfall_nse_flow(subs):
             {
                 "id": 4253560,
                 "variable": "flow",
-                "value": 10,
+                "value": 10.0,
                 "date": pd.to_datetime("2021-01-01").date(),
             },
             {
                 "id": "",
                 "variable": "flow",
-                "value": 5,
+                "value": 5.0,
                 "date": pd.to_datetime("2021-01-01").date(),
             },
             {
                 "id": 4253560,
                 "variable": "flow",
-                "value": 5,
+                "value": 5.0,
                 "date": pd.to_datetime("2021-01-01 00:00:05"),
             },
             {
                 "id": "",
                 "variable": "flow",
-                "value": 2,
+                "value": 2.0,
                 "date": pd.to_datetime("2021-01-01 00:00:05"),
             },
         ]


### PR DESCRIPTION
# Description

Get rid of this warning, as behaviour will break with `networkx==3.6.X`

Maybe update test runner to python 11 or 12 so it uses the newer dependency packages

Fixes #466 