### PR TITLE
chore(ci): disable bot auto-merge workflow (maintainer fix for PR #468)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
+    if: false  # zeroclaw maintainer: bot workflow auto-merge disabled pending human review
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: docs/paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
Maintainer automation from zeroclaw `scripts/swmmanywhere_maintainer.py`.

- **Bot PR:** #468
- **Original branch:** `dependabot/github_actions/actions/upload-artifact-7`
- **Original title:** Bump actions/upload-artifact from 4 to 7
