### PR TITLE
chore(ci): disable bot auto-merge workflow (maintainer fix for PR #459)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
+    if: false  # zeroclaw maintainer: bot workflow auto-merge disabled pending human review
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: |

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,7 +8,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'

--- a/.github/workflows/ci_template.yml
+++ b/.github/workflows/ci_template.yml
@@ -24,7 +24,7 @@ jobs:
         os: ${{fromJson(inputs.os)}}
         python-version: ${{fromJson(inputs.python-version)}}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -39,7 +39,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
     needs: publish-PyPI
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Maintainer automation from zeroclaw `scripts/swmmanywhere_maintainer.py`.

- **Bot PR:** #459
- **Original branch:** `dependabot/github_actions/actions/checkout-6`
- **Original title:** Bump actions/checkout from 5 to 6
