### PR TITLE
chore(ci): disable bot auto-merge workflow (maintainer fix for PR #458)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
+    if: false  # zeroclaw maintainer: bot workflow auto-merge disabled pending human review
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,25 +5,25 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.14.4"
+    rev: "v0.15.7"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.18.2"
+    rev: "v1.19.1"
     hooks:
       - id: mypy
         additional_dependencies:
           [types-requests, types-PyYAML]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013", "--disable", "MD025", "--"]
         
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     - id: codespell
       name: Check common misspellings in text files with codespell.
@@ -31,13 +31,13 @@ repos:
       - tomli
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.11.1
+    rev: v2.20.0
     hooks:
     - id: pyproject-fmt
       name: Apply a consistent format to pyproject.toml
   
   - repo: https://github.com/dosisod/refurb
-    rev: v2.2.0
+    rev: v2.3.0
     hooks:
     - id: refurb
       name: Modernizing Python codebases using Refurb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,29 +90,21 @@ urls.Documentation = "https://imperialcollegelondon.github.io/SWMManywhere/"
 urls.Issues = "https://github.com/ImperialCollegeLondon/SWMManywhere/issues"
 urls.Source = "https://github.com/ImperialCollegeLondon/SWMManywhere"
 
-[tool.hatch.build.targets.wheel]
-only-include = [ "src" ]
-sources = [ "src" ]
-
-[tool.hatch.build.targets.sdist]
-exclude = [
+[tool.hatch]
+build.hooks.vcs.version-file = "_version.py"
+build.targets.sdist.exclude = [
   "*.zip",
 ]
-
-[tool.hatch.metadata]
-license = "BSD-3-clause"                                 # Or your primary license name
-license-files = [ "LICENSE", "src/netcomp/LICENSE.txt" ]
-
-[tool.hatch.version]
-source = "vcs"
-
-[tool.hatch.build.hooks.vcs]
-version-file = "_version.py"
+build.targets.wheel.only-include = [ "src" ]
+build.targets.wheel.sources = [ "src" ]
+metadata.license = "BSD-3-clause"  # Or your primary license name
+metadata.license-files = [ "LICENSE", "src/netcomp/LICENSE.txt" ]
+version.source = "vcs"
 
 [tool.ruff]
-lint.select = [ "D", "E", "F", "I" ]                                   # pydocstyle, pycodestyle, Pyflakes, isort
+lint.select = [ "D", "E", "F", "I" ]  # pydocstyle, pycodestyle, Pyflakes, isort
 lint.per-file-ignores."docs/notebooks/*" = [ "D100" ]
-lint.per-file-ignores."src/netcomp/*" = [ "D", "F" ]                   # Ignore all checks for netcomp
+lint.per-file-ignores."src/netcomp/*" = [ "D", "F" ]  # Ignore all checks for netcomp
 lint.per-file-ignores."tests/*" = [ "D100", "D104" ]
 lint.isort.known-first-party = [ "swmmanywhere", "netcomp" ]
 lint.isort.required-imports = [ "from __future__ import annotations" ]
@@ -122,36 +114,6 @@ lint.pydocstyle.convention = "google"
 skip = "src/swmmanywhere/defs/iso_converter.yml,*.inp,docs/paper/*"
 ignore-words-list = "gage,gages,Carrer,anc"
 
-[tool.pytest.ini_options]
-addopts = "-v --cov=src/swmmanywhere --cov-report=xml --doctest-modules --ignore=src/swmmanywhere/logging.py"
-markers = [
-  "downloads: mark a test as requiring downloads",
-]
-
-[tool.coverage.report]
-exclude_lines = [
-  "if TYPE_CHECKING:",
-]
-omit = [
-  "**/__init__.py",
-]
-ignore_errors = true
-
-[tool.coverage.paths]
-source = [ "src", "*/site-packages" ]
-omit = [
-  "**/__init__.py",
-]
-
-[tool.coverage.run]
-branch = true
-source = [
-  "swmmanywhere",
-]
-omit = [
-  "**/__init__.py",
-]
-
 [tool.mypy]
 disallow_any_explicit = false
 disallow_any_generics = false
@@ -159,13 +121,36 @@ warn_unreachable = true
 warn_unused_ignores = false
 disallow_untyped_defs = false
 exclude = [ ".venv/" ]
+overrides = [ { module = "tests.*", disallow_untyped_defs = false } ]
 
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
+[tool.pytest]
+ini_options.addopts = "-v --cov=src/swmmanywhere --cov-report=xml --doctest-modules --ignore=src/swmmanywhere/logging.py"
+ini_options.markers = [
+  "downloads: mark a test as requiring downloads",
+]
+
+[tool.coverage]
+run.branch = true
+run.omit = [
+  "**/__init__.py",
+]
+run.source = [
+  "swmmanywhere",
+]
+paths.omit = [
+  "**/__init__.py",
+]
+paths.source = [ "src", "*/site-packages" ]
+report.exclude_lines = [
+  "if TYPE_CHECKING:",
+]
+report.ignore_errors = true
+report.omit = [
+  "**/__init__.py",
+]
 
 [tool.refurb]
 ignore = [
-  184, # Because some frankly bizarre suggestions
-  109, # Because pyyaml doesn't support tuples
+  184,  # Because some frankly bizarre suggestions
+  109,  # Because pyyaml doesn't support tuples
 ]


### PR DESCRIPTION
Maintainer automation from zeroclaw `scripts/swmmanywhere_maintainer.py`.

- **Bot PR:** #458
- **Original branch:** `pre-commit-ci-update-config`
- **Original title:** [pre-commit.ci] pre-commit autoupdate
