### PR TITLE
fix(ci): pre-commit — PR #458

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         additional_dependencies:
           [types-requests, types-PyYAML]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.44.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013", "--disable", "MD025", "--"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,25 +5,25 @@ repos:
       - id: check-merge-conflict
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.14.4"
+    rev: "v0.15.11"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.18.2"
+    rev: "v1.20.1"
     hooks:
       - id: mypy
         additional_dependencies:
           [types-requests, types-PyYAML]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013", "--disable", "MD025", "--"]
         
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
     - id: codespell
       name: Check common misspellings in text files with codespell.
@@ -31,13 +31,13 @@ repos:
       - tomli
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.11.1
+    rev: v2.21.1
     hooks:
     - id: pyproject-fmt
       name: Apply a consistent format to pyproject.toml
   
   - repo: https://github.com/dosisod/refurb
-    rev: v2.2.0
+    rev: v2.3.1
     hooks:
     - id: refurb
       name: Modernizing Python codebases using Refurb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,29 +90,21 @@ urls.Documentation = "https://imperialcollegelondon.github.io/SWMManywhere/"
 urls.Issues = "https://github.com/ImperialCollegeLondon/SWMManywhere/issues"
 urls.Source = "https://github.com/ImperialCollegeLondon/SWMManywhere"
 
-[tool.hatch.build.targets.wheel]
-only-include = [ "src" ]
-sources = [ "src" ]
-
-[tool.hatch.build.targets.sdist]
-exclude = [
+[tool.hatch]
+build.hooks.vcs.version-file = "_version.py"
+build.targets.sdist.exclude = [
   "*.zip",
 ]
-
-[tool.hatch.metadata]
-license = "BSD-3-clause"                                 # Or your primary license name
-license-files = [ "LICENSE", "src/netcomp/LICENSE.txt" ]
-
-[tool.hatch.version]
-source = "vcs"
-
-[tool.hatch.build.hooks.vcs]
-version-file = "_version.py"
+build.targets.wheel.only-include = [ "src" ]
+build.targets.wheel.sources = [ "src" ]
+metadata.license = "BSD-3-clause"  # Or your primary license name
+metadata.license-files = [ "LICENSE", "src/netcomp/LICENSE.txt" ]
+version.source = "vcs"
 
 [tool.ruff]
-lint.select = [ "D", "E", "F", "I" ]                                   # pydocstyle, pycodestyle, Pyflakes, isort
+lint.select = [ "D", "E", "F", "I" ]  # pydocstyle, pycodestyle, Pyflakes, isort
 lint.per-file-ignores."docs/notebooks/*" = [ "D100" ]
-lint.per-file-ignores."src/netcomp/*" = [ "D", "F" ]                   # Ignore all checks for netcomp
+lint.per-file-ignores."src/netcomp/*" = [ "D", "F" ]  # Ignore all checks for netcomp
 lint.per-file-ignores."tests/*" = [ "D100", "D104" ]
 lint.isort.known-first-party = [ "swmmanywhere", "netcomp" ]
 lint.isort.required-imports = [ "from __future__ import annotations" ]
@@ -122,36 +114,6 @@ lint.pydocstyle.convention = "google"
 skip = "src/swmmanywhere/defs/iso_converter.yml,*.inp,docs/paper/*"
 ignore-words-list = "gage,gages,Carrer,anc"
 
-[tool.pytest.ini_options]
-addopts = "-v --cov=src/swmmanywhere --cov-report=xml --doctest-modules --ignore=src/swmmanywhere/logging.py"
-markers = [
-  "downloads: mark a test as requiring downloads",
-]
-
-[tool.coverage.report]
-exclude_lines = [
-  "if TYPE_CHECKING:",
-]
-omit = [
-  "**/__init__.py",
-]
-ignore_errors = true
-
-[tool.coverage.paths]
-source = [ "src", "*/site-packages" ]
-omit = [
-  "**/__init__.py",
-]
-
-[tool.coverage.run]
-branch = true
-source = [
-  "swmmanywhere",
-]
-omit = [
-  "**/__init__.py",
-]
-
 [tool.mypy]
 disallow_any_explicit = false
 disallow_any_generics = false
@@ -159,13 +121,36 @@ warn_unreachable = true
 warn_unused_ignores = false
 disallow_untyped_defs = false
 exclude = [ ".venv/" ]
+overrides = [ { module = "tests.*", disallow_untyped_defs = false } ]
 
-[[tool.mypy.overrides]]
-module = "tests.*"
-disallow_untyped_defs = false
+[tool.pytest]
+ini_options.addopts = "-v --cov=src/swmmanywhere --cov-report=xml --doctest-modules --ignore=src/swmmanywhere/logging.py"
+ini_options.markers = [
+  "downloads: mark a test as requiring downloads",
+]
+
+[tool.coverage]
+run.branch = true
+run.omit = [
+  "**/__init__.py",
+]
+run.source = [
+  "swmmanywhere",
+]
+paths.omit = [
+  "**/__init__.py",
+]
+paths.source = [ "src", "*/site-packages" ]
+report.exclude_lines = [
+  "if TYPE_CHECKING:",
+]
+report.ignore_errors = true
+report.omit = [
+  "**/__init__.py",
+]
 
 [tool.refurb]
 ignore = [
-  184, # Because some frankly bizarre suggestions
-  109, # Because pyyaml doesn't support tuples
+  184,  # Because some frankly bizarre suggestions
+  109,  # Because pyyaml doesn't support tuples
 ]


### PR DESCRIPTION
Automated fix targeting [`ImperialCollegeLondon/SWMManywhere`#458](https://github.com/ImperialCollegeLondon/SWMManywhere/pull/458).

## What failed (classification)

- **Kind:** `pre_commit` (pre-commit)
- **Notes:** pre-agent full pre-commit check failed; no hook id lines parsed

## Reproduce locally

- **Strategy:** pre-commit all hooks (pre-agent failure)

Command used for the final green verify:

```text
pip install -e ".[dev]" && pre-commit run --all-files
```

## Failing CI run

- **Could not resolve a run via API:** no failed GitHub Actions workflow run found for this head (sha=86a5849…); need a completed run with conclusion=failure

```
no failed GitHub Actions workflow run found for this head (sha=86a5849…); need a completed run with conclusion=failure
```

## Local verify (after agent edits)

Final successful run of the same repro command (truncated if long):

```text

Requirement already satisfied: aenum>=3.1.11 in /home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages (from pyswmm->swmmanywhere==0.2.2.dev10+g86a584978.d20260427) (3.1.11)
Requirement already satisfied: iniconfig>=1.0.1 in /home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages (from pytest->swmmanywhere==0.2.2.dev10+g86a584978.d20260427) (2.3.0)
Requirement already satisfied: pluggy<2,>=1.5 in /home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages (from pytest->swmmanywhere==0.2.2.dev10+g86a584978.d20260427) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in /home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages (from pytest->swmmanywhere==0.2.2.dev10+g86a584978.d20260427) (2.20.0)
Requirement already satisfied: coverage>=7.10.6 in /home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages (from coverage[toml]>=7.10.6->pytest-cov->swmmanywhere==0.2.2.dev10+g86a584978.d20260427) (7.10.7)
Requirement already satisfied: cligj>=0.5 in /home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages (from rasterio->swmmanywhere==0.2.2.dev10+g86a584978.d20260427) (0.7.2)
Requirement already satisfied: click-plugins in /home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages (from rasterio->swmmanywhere==0.2.2.dev10+g86a584978.d20260427) (1.1.1)
Building wheels for collected packages: swmmanywhere
  Building editable for swmmanywhere (pyproject.toml): started
  Building editable for swmmanywhere (pyproject.toml): finished with status 'done'
  Created wheel for swmmanywhere: filename=swmmanywhere-0.2.2.dev10+g86a584978.d20260427-py3-none-any.whl size=4635 sha256=4b1e79468704354386db86481e71e1ce7bab017bfc9dd624343a818bf89c8583
  Stored in directory: /tmp/pip-ephem-wheel-cache-597dd0qx/wheels/b5/ca/46/d0c089262efe9ff249b8cc5c69bef444af4ed5946bcfe97b25
Successfully built swmmanywhere
Installing collected packages: swmmanywhere
  Attempting uninstall: swmmanywhere
    Found existing installation: swmmanywhere 0.2.2.dev10+g86a584978.d20260427
    Uninstalling swmmanywhere-0.2.2.dev10+g86a584978.d20260427:
      Successfully uninstalled swmmanywhere-0.2.2.dev10+g86a584978.d20260427
Successfully installed swmmanywhere-0.2.2.dev10+g86a584978.d20260427
check for merge conflicts.....................................................Passed
debug statements (python).....................................................Passed
ruff (legacy alias)...........................................................Passed
ruff format...................................................................Passed
mypy..........................................................................Passed
markdownlint..................................................................Passed
Check common misspellings in text files with codespell........................Passed
Apply a consistent format to pyproject.toml...................................Passed
Modernizing Python codebases using Refurb.....................................Passed

ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
ukswmm 0.1.0 requires swmmanywhere<0.2.0,>=0.1.16, but you have swmmanywhere 0.2.2.dev10+g86a584978.d20260427 which is incompatible.
```

## Review required (agent-flagged)

The automated agent flagged changes that a human should double-check before merging:

1. 🟠 **MEDIUM** — Downgraded markdownlint-cli from v0.48.0 to v0.44.0 to maintain compatibility with Node.js <20 in CI environments. This is a temporary workaround; ideally, CI agents should be upgraded to Node.js >=20.
   - Files: `.pre-commit-config.yaml`

### Upstream changelog / release notes (cross-reference)
<details><summary>https://github.com/astral-sh/ruff-pre-commit/compare/v0.14.4...v0.15.11</summary>

Comparing v0.14.4...v0.15.11 · astral-sh/ruff-pre-commit · GitHub Skip to content Navigation Menu Toggle navigation Sign in Appearance settings Platform AI CODE CREATION GitHub Copilot Write better code with AI GitHub Spark Build and deploy intelligent apps GitHub Models Manage and compare prompts MCP Registry New Integrate external tools DEVELOPER WORKFLOWS Actions Automate any workflow Codespaces Instant dev environments Issues Plan and track work <svg data-component="Octicon" aria-hidden="true" focusable="false" cl

</details>
<details><summary>https://github.com/pre-commit/mirrors-mypy/compare/v1.18.2...v1.20.1</summary>

Comparing v1.18.2...v1.20.1 · pre-commit/mirrors-mypy · GitHub Skip to content Navigation Menu Toggle navigation Sign in Appearance settings Platform AI CODE CREATION GitHub Copilot Write better code with AI GitHub Spark Build and deploy intelligent apps GitHub Models Manage and compare prompts MCP Registry New Integrate external tools DEVELOPER WORKFLOWS Actions Automate any workflow Codespaces Instant dev environments Issues Plan and track work <svg data-component="Octicon" aria-hidden="true" focusable="false" class="octicon octicon-code NavLink-module__

</details>

## Run metadata

- **Agent:** provider `deepinfra`, model `Qwen/Qwen3-Next-80B-A3B-Instruct`
- **Succeeded on maintainer round:** 1 (of automated rounds)

Session debug files under `maintainer_state/` are omitted from this branch by default; they are summarised above when relevant.