### PR TITLE
fix(ci): pytest — PR #468

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,7 +105,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: docs/paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled

--- a/src/swmmanywhere/prepare_data.py
+++ b/src/swmmanywhere/prepare_data.py
@@ -278,16 +278,15 @@ def download_elevation(fid: Path, bbox: tuple[float, float, float, float]) -> No
         collections=["nasadem"],
         bbox=bbox,
     )
-    
+
     # Handle pystac-client v0.x and v1.x compatibility
     if Version(pystac_client.__version__) >= Version("1.0.0"):
         items = search.item_collection().items
     else:
         items = search.items()
-    
+
     signed_asset = (
-        planetary_computer.sign(item.assets["elevation"]).href
-        for item in items
+        planetary_computer.sign(item.assets["elevation"]).href for item in items
     )
     dem = rxr_merge.merge_arrays(
         [rioxarray.open_rasterio(href).squeeze(drop=True) for href in signed_asset]

--- a/src/swmmanywhere/prepare_data.py
+++ b/src/swmmanywhere/prepare_data.py
@@ -278,9 +278,16 @@ def download_elevation(fid: Path, bbox: tuple[float, float, float, float]) -> No
         collections=["nasadem"],
         bbox=bbox,
     )
+    
+    # Handle pystac-client v0.x and v1.x compatibility
+    if Version(pystac_client.__version__) >= Version("1.0.0"):
+        items = search.item_collection().items
+    else:
+        items = search.items()
+    
     signed_asset = (
         planetary_computer.sign(item.assets["elevation"]).href
-        for item in search.items()
+        for item in items
     )
     dem = rxr_merge.merge_arrays(
         [rioxarray.open_rasterio(href).squeeze(drop=True) for href in signed_asset]


### PR DESCRIPTION
Automated fix targeting [`ImperialCollegeLondon/SWMManywhere`#468](https://github.com/ImperialCollegeLondon/SWMManywhere/pull/468).

## What failed (classification)

- **Kind:** `pytest` (pytest)
- **Notes:** parsed pytest FAILED/ERROR lines
- **Pytest nodes (from CI log):**
  - `tests/test_swmmanywhere.py::test_swmmanywhere[True]`

## Reproduce locally

- **Strategy:** targeted pytest: 1 node(s)

Command used for the final green verify:

```text
pixi run --manifest-path /home/barney/Documents/GitHub/SWMManywhere/pixi.toml pytest -q 'tests/test_swmmanywhere.py::test_swmmanywhere[True]'
```

## Failing CI run

- **Workflow run:** [25048423755](https://github.com/ImperialCollegeLondon/SWMManywhere/actions/runs/25048423755) (head `af920ab…`)

Excerpt from downloaded Actions logs (may be truncated):

```text
FAILURES ===================================
2026-04-28T12:23:46.6109291Z ___________________________ test_swmmanywhere[True] ___________________________
2026-04-28T12:23:46.6109711Z 
2026-04-28T12:23:46.6109866Z run = True
2026-04-28T12:23:46.6110603Z wbt_zip_path = WindowsPath('D:/a/SWMManywhere/SWMManywhere/tests/wbt_zip/WhiteboxTools_win_amd64.zip')
2026-04-28T12:23:46.6111555Z 
2026-04-28T12:23:46.6111834Z     @pytest.mark.parametrize("run", [True, False])
2026-04-28T12:23:46.6112504Z     def test_swmmanywhere(run, wbt_zip_path):
2026-04-28T12:23:46.6112978Z         """Test the swmmanywhere function."""
2026-04-28T12:23:46.6113378Z         with tempfile.TemporaryDirectory(dir=".") as temp_dir:
2026-04-28T12:23:46.6113738Z             # Load the config
2026-04-28T12:23:46.6114100Z             test_data_dir = Path(__file__).parent / "test_data"
2026-04-28T12:23:46.6114579Z             defs_dir = Path(__file__).parent.parent / "src" / "swmmanywhere" / "defs"
2026-04-28T12:23:46.6115019Z             with (defs_dir / "demo_config.yml").open("r") as f:
2026-04-28T12:23:46.6146031Z                 config = yaml.safe_load(f)
2026-04-28T12:23:46.6146770Z     
2026-04-28T12:23:46.6147096Z             # Set some test values
2026-04-28T12:23:46.6147468Z             base_dir = Path(temp_dir)
2026-04-28T12:23:46.6147937Z             config["base_dir"] = str(base_dir)
2026-04-28T12:23:46.6148476Z             config["bbox"] = [0.05677, 51.55656, 0.07193, 51.56726]
2026-04-28T12:23:46.6149066Z             config["address_overrides"] = {
2026-04-28T12:23:46.6149630Z                 "building": str(test_data_dir / "building.geoparquet"),
2026-04-28T12:23:46.6150327Z                 "whiteboxtools_binaries_zip": str(wbt_zip_path),
2026-04-28T12:23:46.6150866Z             }
2026-04-28T12:23:46.6151208Z             config["parameter_overrides"] = {
2026-04-28T12:23:46.6151809Z                 "subcatchment_derivation": {"subbasin_streamorder": 5}
2026-04-28T12:23:46.6152345Z             }
2026-04-28T12:23:46.6152733Z             config["run_settings"]["duration"] = 1000
2026-04-28T12:23:46.6153203Z             config["model_number"] = 0
2026-04-28T12:23:46.6153598Z     
2026-04-28T12:23:46.6154044Z             # Fill the real dict with unused paths to avoid filevalidation errors
2026-04-28T12:23:46.6154812Z             config["real"]["subcatchments"] = str(defs_dir / "storm.dat")
2026-04-28T12:23:46.6155459Z             config["real"]["inp"] = str(defs_dir / "storm.dat")
2026-04-28T12:23:46.6156387Z             config["real"]["graph"] = str(defs_dir / "storm.dat")
2026-04-28T12:23:46.6156914Z     
2026-04-28T12:23:46.6157214Z             # Write the config
2026-04-28T12:23:46.6157711Z             with open(base_dir / "test_config.yml", "w") as f:
2026-04-28T12:23:46.6158218Z                 yaml.dump(config, f)
2026-04-28T12:23:46.6158647Z     
2026-04-28T12:23:46.6158976Z             # Load and test validation of the config
2026-04-28T12:23:46.6159626Z             config = swmmanywhere.load_config(base_dir / "test_config.yml")
2026-04-28T12:23:46.6160213Z     
2026-04-28T12:23:46.6160573Z             # Set the test config to just use the generated data
2026-04-28T12:23:46.6161177Z             model_dir = base_dir / "demo" / "bbox_1" / "model_0"
2026-04-28T12:23:46.6162069Z             config["real"]["subcatchments"] = model_dir / "subcatchments.geoparquet"
2026-04-28T12:23:46.6162807Z             config["real"]["inp"] = model_dir / "model_0.inp"
2026-04-28T12:23:46.6163418Z             config["real"]["graph"] = model_dir / "graph.parquet"
2026-04-28T12:23:46.6164001Z             config["run_model"] = run
2026-04-28T12:23:46.6164429Z     
2026-04-28T12:23:46.6164707Z             # Run swmmanywhere
2026-04-28T12:23:46.6165188Z             os.environ["SWMMANYWHERE_VERBOSE"] = "true"
2026-04-28T12:23:46.6165751Z             inp, metrics = swmmanywhere.swmmanywhere(config)
2026-04-28T12:23:46.6166439Z     
2026-04-28T12:23:46.6166760Z             # Check what was generated
2026-04-28T12:23:46.6167390Z             assert (inp.parent / f"{config['graphfcn_list'][-1]}_graph.json").exists()
2026-04-28T12:23:46.6168009Z             assert inp.exists()
2026-04-28T12:23:46.6168423Z     
2026-04-28T12:23:46.6168826Z             assert (inp.parent / "edges.geoparquet").exists()
2026-04-28T12:23:46.6169430Z             assert (inp.parent / "nodes.geoparquet").exists()
2026-04-28T12:23:46.6
... [failures excerpt truncated to 4500 chars]
```

## Local verify (after agent edits)

Final successful run of the same repro command (truncated if long):

```text
]
tests/test_swmmanywhere.py::test_swmmanywhere[True]
tests/test_swmmanywhere.py::test_swmmanywhere[True]
tests/test_swmmanywhere.py::test_swmmanywhere[True]
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr475-1777404628/src/swmmanywhere/metric_utilities.py:487: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.
    val = results.groupby(gb_key).apply(lambda x: coef_func(x.value_real, x.value_syn))

tests/test_swmmanywhere.py: 482 warnings
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr475-1777404628/src/swmmanywhere/metric_utilities.py:1067: DeprecationWarning: `trapz` is deprecated. Use `trapezoid` instead, or one of the numerical integration functions in `scipy.integrate`.
    return np.trapz(x.value, x.duration)

tests/test_swmmanywhere.py::test_swmmanywhere[True]
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr475-1777404628/src/swmmanywhere/metric_utilities.py:1069: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.
    syn_flooding = extract_var(synthetic_results, "flooding").groupby("id").apply(_f)

tests/test_swmmanywhere.py::test_swmmanywhere[True]
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr475-1777404628/src/swmmanywhere/metric_utilities.py:1073: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.
    real_flooding = extract_var(real_results, "flooding").groupby("id").apply(_f)

tests/test_swmmanywhere.py::test_swmmanywhere[True]
tests/test_swmmanywhere.py::test_swmmanywhere[True]
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr475-1777404628/src/netcomp/linalg/eigenstuff.py:69: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
    evecs = np.matrix(evecs[:, inds])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.12.13-final-0 _______________

Coverage XML written to file coverage.xml
================= 1 passed, 502 warnings in 101.65s (0:01:41) ==================

/home/barney/Documents/GitHub/pr-maintainer/.pixi/envs/default/lib/python3.12/site-packages/coverage/control.py:946: CoverageWarning: No data was collected. (no-data-collected); see https://coverage.readthedocs.io/en/7.10.7/messages.html#warning-no-data-collected
  self._warn("No data was collected.", slug="no-data-collected")
```

## Mechanical CI context
- Local reproduction command: `pixi run --manifest-path /home/barney/Documents/GitHub/SWMManywhere/pixi.toml pytest -q 'tests/test_swmmanywhere.py::test_swmmanywhere[True]'`
- CI command inferred from logs: `pytest`
- Suggested sanity command(s): `pytest`
- Failure mode signals: normal_assertion
- Confidence: high
- Mechanical risk notes:
  - Local reproduction command differs from the apparent CI command.

## Review required (agent-flagged)

The automated agent flagged changes that a human should double-check before merging:

1. 🟠 **MEDIUM** — Modified pystac_client usage to be compatible with both v0.x and v1.x. CI failure was due to pystac-client v1.x API change (search.items() is now a property, not a method). This change ensures compatibility without breaking older versions.
   - Files: `src/swmmanywhere/prepare_data.py`

### Upstream changelog / release notes (cross-reference)
<details><summary>https://github.com/actions/upload-artifact</summary>

GitHub - actions/upload-artifact · GitHub Skip to content Navigation Menu Toggle navigation Sign in Appearance settings Platform AI CODE CREATION GitHub Copilot Write better code with AI GitHub Spark Build and deploy intelligent apps GitHub Models Manage and compare prompts MCP Registry New Integrate external tools DEVELOPER WORKFLOWS <a href="https://github.com/features/actions" data-analytics-event="{&quot;action&quot;:&quot;actions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;location&quot;:&quot;navbar&quot;,&quot;label&quot;:&quot;actions_link_plat …

</details>
<details><summary>https://github.com/actions/upload-artifact/releases</summary>

Releases · actions/upload-artifact · GitHub Skip to content Navigation Menu Toggle navigation Sign in Appearance settings Platform AI CODE CREATION GitHub Copilot Write better code with AI GitHub Spark Build and deploy intelligent apps GitHub Models Manage and compare prompts MCP Registry New Integrate external tools DEVELOPER WORKFLOWS Actions Automate any workflow Codespaces Instant dev environments Issues Plan and track work Code Review Manage code changes APPLICATION SECURITY <a href="https://github.com/security/advanced-security" data-analytics-event="{&quot;action&quot;:&quot;github_adva …

</details>

## Run metadata

- **Agent:** provider `deepinfra`, model `Qwen/Qwen3-Next-80B-A3B-Instruct`
- **Succeeded on maintainer round:** 1 (of automated rounds)

Session debug files under `maintainer_state/` are omitted from this branch by default; they are summarised above when relevant.