### PR TITLE
fix(ci): pytest — PR #467

### DIFF
--- a/src/swmmanywhere/misc/debug_derive_rc.py
+++ b/src/swmmanywhere/misc/debug_derive_rc.py
@@ -79,7 +79,7 @@ def derive_rc_alt(
     )
 
     # Store as impervious area in subcatchments
-    subcatchments["impervious_area"] = 0
+    subcatchments["impervious_area"] = 0.0
     subcatchments.loc[areas.index, "impervious_area"] = areas
     subcatchments["rc"] = (
         subcatchments["impervious_area"] / subcatchments.geometry.area * 100

--- a/tests/test_metric_utilities.py
+++ b/tests/test_metric_utilities.py
@@ -285,25 +285,25 @@ def test_outfall_nse_flow(subs):
             {
                 "id": 4253560,
                 "variable": "flow",
-                "value": 10,
+                "value": 10.0,
                 "date": pd.to_datetime("2021-01-01").date(),
             },
             {
                 "id": "",
                 "variable": "flow",
-                "value": 5,
+                "value": 5.0,
                 "date": pd.to_datetime("2021-01-01").date(),
             },
             {
                 "id": 4253560,
                 "variable": "flow",
-                "value": 5,
+                "value": 5.0,
                 "date": pd.to_datetime("2021-01-01 00:00:05"),
             },
             {
                 "id": "",
                 "variable": "flow",
-                "value": 2,
+                "value": 2.0,
                 "date": pd.to_datetime("2021-01-01 00:00:05"),
             },
         ]


### PR DESCRIPTION
Automated fix targeting [`ImperialCollegeLondon/SWMManywhere`#467](https://github.com/ImperialCollegeLondon/SWMManywhere/pull/467).

## What failed (classification)

- **Kind:** `pytest` (pytest)
- **Notes:** parsed pytest FAILED/ERROR lines
- **Pytest nodes (from CI log):**
  - `tests/test_geospatial_utilities.py::test_derive_rc`
  - `tests/test_metric_utilities.py::test_outfall_nse_flow`
  - `tests/test_swmmanywhere.py::test_swmmanywhere[True]`

## Reproduce locally

- **Strategy:** targeted pytest: 3 node(s) across CI Python matrix (3.10, 3.12)

Command used for the final green verify:

```text
set +e; __prm_worktree='/home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr467-1778151564'; __prm_versions='3.10 3.12'; __prm_pytest_display='tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow '"'"'tests/test_swmmanywhere.py::test_swmmanywhere[True]'"'"''; __prm_fallback='pixi run --manifest-path /home/barney/Documents/GitHub/SWMManywhere/pixi.toml pytest -q tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow '"'"'tests/test_swmmanywhere.py::test_swmmanywhere[True]'"'"''; cd "$__prm_worktree" || exit 2; __prm_matrix_rc=0; __prm_any_run=0; echo '=== pr-maintainer: CI Python pytest matrix ==='; for __prm_pyver in $__prm_versions; do echo "=== python ${__prm_pyver}: pytest ${__prm_pytest_display} ==="; __prm_pybin=$(command -v "python${__prm_pyver}" 2>/dev/null || true); if [ -z "$__prm_pybin" ]; then echo "python${__prm_pyver} not available locally; skipping this CI matrix version"; continue; fi; __prm_any_run=1; if [ -f pyproject.toml ] && grep -q '^\[tool\.poetry\]' pyproject.toml; then if ! command -v poetry >/dev/null 2>&1; then echo 'poetry is not available locally for this CI matrix version'; __prm_rc=127; else __prm_poetry_home="$__prm_worktree/maintainer_state/poetry-venvs"; mkdir -p "$__prm_poetry_home"; POETRY_VIRTUALENVS_PATH="$__prm_poetry_home" poetry env use "$__prm_pybin" && POETRY_VIRTUALENVS_PATH="$__prm_poetry_home" poetry install && POETRY_VIRTUALENVS_PATH="$__prm_poetry_home" poetry run pytest -q tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow 'tests/test_swmmanywhere.py::test_swmmanywhere[True]'; __prm_rc=$?; fi; else __prm_pyver_compact=$(printf '%s' "$__prm_pyver" | tr -d .); __prm_env="$__prm_worktree/maintainer_state/python-matrix/py${__prm_pyver_compact}"; "$__prm_pybin" -m venv "$__prm_env" && "$__prm_env/bin/python" -m pip install --upgrade pip >/dev/null && "$__prm_env/bin/python" -m pip install -e '.[dev]' && "$__prm_env/bin/python" -m pytest -q tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow 'tests/test_swmmanywhere.py::test_swmmanywhere[True]'; __prm_rc=$?; fi; if [ "$__prm_rc" -ne 0 ]; then __prm_matrix_rc="$__prm_rc"; fi; done; if [ "$__prm_any_run" -eq 0 ]; then echo 'No configured CI Python interpreters were available locally; falling back to original verify command.'; sh -c "$__prm_fallback"; __prm_matrix_rc=$?; fi; exit "$__prm_matrix_rc"
```

## Failing CI run

- **Workflow run:** [25483061266](https://github.com/ImperialCollegeLondon/SWMManywhere/actions/runs/25483061266) (head `e56de45…`)

Excerpt from downloaded Actions logs (may be truncated):

```text
FAILURES ===================================
2026-05-07T09:05:21.0715336Z _______________________________ test_derive_rc ________________________________
2026-05-07T09:05:21.0716019Z 
2026-05-07T09:05:21.0716730Z self = NumpyBlock: 3 dtype: int64, indexer = (array([0, 1]),)
2026-05-07T09:05:21.0718141Z value = array([551.31653226, 461.68346774])
2026-05-07T09:05:21.0718534Z 
2026-05-07T09:05:21.0719140Z     def setitem(self, indexer, value) -> Block:
2026-05-07T09:05:21.0719713Z         """
2026-05-07T09:05:21.0720307Z         Attempt self.values[indexer] = value, possibly creating a new array.
2026-05-07T09:05:21.0720968Z     
2026-05-07T09:05:21.0721294Z         Parameters
2026-05-07T09:05:21.0721656Z         ----------
2026-05-07T09:05:21.0722069Z         indexer : tuple, list-like, array-like, slice, int
2026-05-07T09:05:21.0722654Z             The subset of self.values to set
2026-05-07T09:05:21.0723108Z         value : object
2026-05-07T09:05:21.0723567Z             The value being set
2026-05-07T09:05:21.0724043Z     
2026-05-07T09:05:21.0724395Z         Returns
2026-05-07T09:05:21.0724782Z         -------
2026-05-07T09:05:21.0725204Z         Block
2026-05-07T09:05:21.0725621Z     
2026-05-07T09:05:21.0725970Z         Notes
2026-05-07T09:05:21.0726379Z         -----
2026-05-07T09:05:21.0726964Z         `indexer` is a direct slice/positional indexer. `value` must
2026-05-07T09:05:21.0727659Z         be a compatible shape.
2026-05-07T09:05:21.0728143Z         """
2026-05-07T09:05:21.0728462Z     
2026-05-07T09:05:21.0857475Z         value = self._standardize_fill_value(value)
2026-05-07T09:05:21.0858073Z     
2026-05-07T09:05:21.0858457Z         values = cast(np.ndarray, self.values)
2026-05-07T09:05:21.0858954Z         if self.ndim == 2:
2026-05-07T09:05:21.0859322Z             values = values.T
2026-05-07T09:05:21.0859719Z     
2026-05-07T09:05:21.0860038Z         # length checking
2026-05-07T09:05:21.0860387Z         check_setitem_lengths(indexer, value, values)
2026-05-07T09:05:21.0860706Z     
2026-05-07T09:05:21.0860916Z         if self.dtype != _dtype_obj:
2026-05-07T09:05:21.0861297Z             # GH48933: extract_array would convert a pd.Series value to np.ndarray
2026-05-07T09:05:21.0861753Z             value = extract_array(value, extract_numpy=True)
2026-05-07T09:05:21.0862068Z         try:
2026-05-07T09:05:21.0862341Z >           casted = np_can_hold_element(values.dtype, value)
2026-05-07T09:05:21.0862688Z                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-05-07T09:05:21.0862882Z 
2026-05-07T09:05:21.0863185Z C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pandas\core\internals\blocks.py:1115: 
2026-05-07T09:05:21.0863732Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2026-05-07T09:05:21.0863969Z 
2026-05-07T09:05:21.0864152Z dtype = dtype('int64'), element = array([551.31653226, 461.68346774])
2026-05-07T09:05:21.0864408Z 
2026-05-07T09:05:21.0864564Z     def np_can_hold_element(dtype: np.dtype, element: Any) -> Any:
2026-05-07T09:05:21.0864913Z         """
2026-05-07T09:05:21.0865202Z         Raise if we cannot losslessly set this element into an ndarray with this dtype.
2026-05-07T09:05:21.0865570Z     
2026-05-07T09:05:21.0865889Z         Specifically about places where we disagree with numpy.  i.e. there are
2026-05-07T09:05:21.0866801Z         cases where numpy will raise in doing the setitem that we do not check
2026-05-07T09:05:21.0867254Z         for here, e.g. setting str "X" into a numeric ndarray.
2026-05-07T09:05:21.0867577Z     
2026-05-07T09:05:21.0867746Z         Returns
2026-05-07T09:05:21.0867956Z         -------
2026-05-07T09:05:21.0868154Z         Any
2026-05-07T09:05:21.0868369Z             The element, potentially cast to the dtype.
2026-05-07T09:05:21.0868691Z     
2026-05-07T09:05:21.0868871Z         Raises
2026-05-07T09:05:21.0869081Z         ------
2026-05-07T09:05:21.0869368Z         ValueError : If we cannot losslessly store this element with this dtype.
2026-05-07T09:05:21.0869720Z         """
2026-05-07T09:05:21.0870041Z         if dtype == _dtype_obj:
2026-05-07T09:05:21.0870430Z             return element
2026-05-07T09:05:21.0870804Z     
2026-05-07T09:05:21.0871150Z         tipo = _maybe_infer_dtype_type(element)
2026-05-07T09:05:21.0872376Z     
2026-05-07T09:05:21.0873233Z         if dtype.kind in "iu":
2026-05-07T09:05:21.087370
... [failures excerpt truncated to 4500 chars]
```

## Local verify (after agent edits)

Final successful run of the same repro command (truncated if long):

```text
45f2.d20260507-py3-none-any.whl size=4633 sha256=88128baa22e490de60bc2ec62f303f135dd732e978318eb17ca7fcecbded2e35
  Stored in directory: /tmp/pip-ephem-wheel-cache-s89lrk4q/wheels/06/67/e3/944716c3d01914034820bc364959ab381f15e4db2ce0c4e759
Successfully built swmmanywhere
Installing collected packages: swmmanywhere
  Attempting uninstall: swmmanywhere
    Found existing installation: swmmanywhere 0.2.2.dev24+ge56de45f2.d20260507
    Uninstalling swmmanywhere-0.2.2.dev24+ge56de45f2.d20260507:
      Successfully uninstalled swmmanywhere-0.2.2.dev24+ge56de45f2.d20260507
Successfully installed swmmanywhere-0.2.2.dev24+ge56de45f2.d20260507
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr467-1778151564
configfile: pyproject.toml
plugins: cov-7.1.0, mock-3.15.1, mypy-1.0.1
collected 3 items

tests/test_geospatial_utilities.py .                                     [ 33%]
tests/test_metric_utilities.py .                                         [ 66%]
tests/test_swmmanywhere.py .                                             [100%]

=============================== warnings summary ===============================
maintainer_state/python-matrix/py312/lib/python3.12/site-packages/planetary_computer/sas.py:40
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr467-1778151564/maintainer_state/python-matrix/py312/lib/python3.12/site-packages/planetary_computer/sas.py:40: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.13/migration/
    class SASBase(BaseModel):

tests/test_geospatial_utilities.py::test_derive_rc
tests/test_geospatial_utilities.py::test_derive_rc
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr467-1778151564/src/swmmanywhere/misc/debug_derive_rc.py:35: DeprecationWarning: The 'unary_union' attribute is deprecated, use the 'union_all()' method instead.
    unified_geom = intersecting_building_geom.unary_union.union(

tests/test_geospatial_utilities.py::test_derive_rc
tests/test_geospatial_utilities.py::test_derive_rc
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr467-1778151564/src/swmmanywhere/misc/debug_derive_rc.py:36: DeprecationWarning: The 'unary_union' attribute is deprecated, use the 'union_all()' method instead.
    intersecting_street_geom.unary_union

tests/test_swmmanywhere.py::test_swmmanywhere[True]
tests/test_swmmanywhere.py::test_swmmanywhere[True]
  /home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr467-1778151564/src/netcomp/linalg/eigenstuff.py:69: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
    evecs = np.matrix(evecs[:, inds])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.12.13-final-0 _______________

Coverage XML written to file coverage.xml
================== 3 passed, 7 warnings in 117.40s (0:01:57) ===================
```

## Mechanical CI context
- Local reproduction command: `set +e; __prm_worktree='/home/barney/.pr-maintainer/worktrees/ImperialCollegeLondon_SWMManywhere-pr467-1778151564'; __prm_versions='3.10 3.12'; __prm_pytest_display='tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow '"'"'tests/test_swmmanywhere.py::test_swmmanywhere[True]'"'"''; __prm_fallback='pixi run --manifest-path /home/barney/Documents/GitHub/SWMManywhere/pixi.toml pytest -q tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow '"'"'tests/test_swmmanywhere.py::test_swmmanywhere[True]'"'"''; cd "$__prm_worktree" || exit 2; __prm_matrix_rc=0; __prm_any_run=0; echo '=== pr-maintainer: CI Python pytest matrix ==='; for __prm_pyver in $__prm_versions; do echo "=== python ${__prm_pyver}: pytest ${__prm_pytest_display} ==="; __prm_pybin=$(command -v "python${__prm_pyver}" 2>/dev/null || true); if [ -z "$__prm_pybin" ]; then echo "python${__prm_pyver} not available locally; skipping this CI matrix version"; continue; fi; __prm_any_run=1; if [ -f pyproject.toml ] && grep -q '^\[tool\.poetry\]' pyproject.toml; then if ! command -v poetry >/dev/null 2>&1; then echo 'poetry is not available locally for this CI matrix version'; __prm_rc=127; else __prm_poetry_home="$__prm_worktree/maintainer_state/poetry-venvs"; mkdir -p "$__prm_poetry_home"; POETRY_VIRTUALENVS_PATH="$__prm_poetry_home" poetry env use "$__prm_pybin" && POETRY_VIRTUALENVS_PATH="$__prm_poetry_home" poetry install && POETRY_VIRTUALENVS_PATH="$__prm_poetry_home" poetry run pytest -q tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow 'tests/test_swmmanywhere.py::test_swmmanywhere[True]'; __prm_rc=$?; fi; else __prm_pyver_compact=$(printf '%s' "$__prm_pyver" | tr -d .); __prm_env="$__prm_worktree/maintainer_state/python-matrix/py${__prm_pyver_compact}"; "$__prm_pybin" -m venv "$__prm_env" && "$__prm_env/bin/python" -m pip install --upgrade pip >/dev/null && "$__prm_env/bin/python" -m pip install -e '.[dev]' && "$__prm_env/bin/python" -m pytest -q tests/test_geospatial_utilities.py::test_derive_rc tests/test_metric_utilities.py::test_outfall_nse_flow 'tests/test_swmmanywhere.py::test_swmmanywhere[True]'; __prm_rc=$?; fi; if [ "$__prm_rc" -ne 0 ]; then __prm_matrix_rc="$__prm_rc"; fi; done; if [ "$__prm_any_run" -eq 0 ]; then echo 'No configured CI Python interpreters were available locally; falling back to original verify command.'; sh -c "$__prm_fallback"; __prm_matrix_rc=$?; fi; exit "$__prm_matrix_rc"`
- CI command inferred from logs: `pytest`
- Suggested sanity command(s): `pytest`
- CI Python version(s) for pytest: `3.10`, `3.12`
- Failure mode signals: normal_assertion
- Confidence: high
- Mechanical risk notes:
  - Local reproduction command differs from the apparent CI command.

## Review required (agent-flagged)

The automated agent flagged changes that a human should double-check before merging:

1. 🟡 **LOW** — Changed `subcatchments["impervious_area"] = 0` to `= 0.0` in debug_derive_rc.py to ensure float dtype in pandas 2.x. This fixes a LossySetitemError in CI but does not change numerical results — only dtype safety. Reviewer should confirm this is a benign type fix.
   - Files: `src/swmmanywhere/misc/debug_derive_rc.py`

## Run metadata

- **Agent:** provider `deepinfra`, model `Qwen/Qwen3-Next-80B-A3B-Instruct`
- **Succeeded on maintainer round:** 2 (of automated rounds)

Session debug files under `maintainer_state/` are omitted from this branch by default; they are summarised above when relevant.