### PR TITLE
Pin affine<3 until pyflwdir supports affine 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "affine<3",
   "cdsapi",
   "cytoolz",
   "folium",


### PR DESCRIPTION
Closes #503.

**Problem observed**

On a fresh `pip install -e .` of `main` (f0c18be) on 2026-09-04, macOS 26.6.2, Python 3.11.15, the resolver picks `affine 3.0.1`, and every run then fails during `clip_to_catchments`:

```
numba.core.errors.TypingError: Failed in nopython mode pipeline (step: nopython frontend)
...
- argument 3: Cannot determine Numba type of <class 'affine.Affine'>
```

`affine` 3.0 turned `Affine` from a namedtuple into a plain class. `pyflwdir.dem.slope` is `@njit`-compiled and receives the raster transform from `geospatial_utilities`; numba could type the old tuple and cannot type the new class. `pyflwdir 0.5.12`, the latest release, has not adapted yet. Installed alongside: `pyflwdir 0.5.12`, `numba 0.67.0`, `rasterio 1.4.4`, `numpy 2.4.6`.

**Change**

Pin `affine<3` in `pyproject.toml`. With `affine 2.4.0` the same environment builds the documentation's Andorra bounding box end to end (together with #502).

The alternative is to pass a plain tuple to `pyflwdir.dem.slope` in `geospatial_utilities` (the numba kernel only indexes `transform[0]`, `[4]` and `[5]`); happy to switch to that if you prefer a code change over a pin.
