### PR TITLE
Fix Overture release id parsing and pin affine<3 (main fails since August)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "affine<3",
   "cdsapi",
   "cytoolz",
   "folium",

--- a/src/swmmanywhere/prepare_data.py
+++ b/src/swmmanywhere/prepare_data.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import operator
+import re
 from contextlib import suppress
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -32,6 +33,10 @@ from pyarrow import fs
 
 from swmmanywhere.logging import logger
 from swmmanywhere.utilities import yaml_load
+
+# Overture release ids look like "2026-08-19.0". The STAC catalog's child hrefs are
+# absolute URLs (https://stac.overturemaps.org/<release>/catalog.json).
+OVERTURE_RELEASE = re.compile(r"\d{4}-\d{2}-\d{2}\.\d+")
 
 
 def get_country(x: float, y: float) -> dict[int, str]:
@@ -83,9 +88,10 @@ def _get_latest_s3_url() -> tuple[str, str]:
     cache_file.parent.mkdir(exist_ok=True)
     s3_region = "us-west-2"
 
-    # Check cache (valid for 72 hours given monthly releases)
-    if cache_file.exists():
-        cache = json.loads(cache_file.read_text())
+    # Check cache (valid for 72 hours given monthly releases). A cache written
+    # before absolute STAC hrefs were handled holds a malformed release; ignore it.
+    cache = json.loads(cache_file.read_text()) if cache_file.exists() else {}
+    if OVERTURE_RELEASE.fullmatch(str(cache.get("release", ""))):
         cached_time = datetime.fromisoformat(cache["timestamp"])
 
         # If cache is less than 72 hours old, use it
@@ -115,7 +121,10 @@ def _get_latest_s3_url() -> tuple[str, str]:
         if link["rel"] == "child" and "release" in link.get("title", "").lower()
     ]
     releases.sort(key=operator.itemgetter("href"), reverse=True)
-    latest = str(Path(releases[0]["href"].rstrip("/")).parent)
+    match = OVERTURE_RELEASE.search(releases[0]["href"])
+    if match is None:
+        raise ValueError(f"No Overture release id in href {releases[0]['href']!r}")
+    latest = match.group(0)
     cache_file.write_text(
         json.dumps({"release": latest, "timestamp": datetime.now().isoformat()})
     )

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -9,7 +9,9 @@ pytest -m downloads
 
 from __future__ import annotations
 
+import json
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
@@ -287,3 +289,63 @@ def test_download_elevation():
             mock_merge_arrays.assert_called_once()
             mock_merged_array.rio.clip_box.assert_called_once_with(*bbox)
             mock_merged_array.rio.to_raster.assert_called_once_with(temp_fid)
+
+
+def test_get_latest_s3_url_parses_absolute_hrefs(tmp_path, monkeypatch):
+    """The release id is read from the catalog's absolute child hrefs."""
+    monkeypatch.chdir(tmp_path)
+    catalog = {
+        "links": [
+            {"rel": "self", "href": "https://stac.overturemaps.org/catalog.json"},
+            {
+                "rel": "child",
+                "title": "Latest Overture Release",
+                "href": "https://stac.overturemaps.org/2026-08-19.0/catalog.json",
+            },
+            {
+                "rel": "child",
+                "title": "2026-07-22.0 Overture Release",
+                "href": "https://stac.overturemaps.org/2026-07-22.0/catalog.json",
+            },
+        ]
+    }
+    with mock.patch.object(downloaders.requests, "get") as mock_get:
+        mock_get.return_value.json.return_value = catalog
+        region, url = downloaders._get_latest_s3_url()
+
+    assert region == "us-west-2"
+    assert url == (
+        "overturemaps-us-west-2/release/2026-08-19.0/theme=buildings/type=building/"
+    )
+    cache = json.loads((tmp_path / ".cache" / "overture_release.json").read_text())
+    assert cache["release"] == "2026-08-19.0"
+
+
+def test_get_latest_s3_url_ignores_malformed_cache(tmp_path, monkeypatch):
+    """A cache holding the old, URL-shaped release is refreshed from the catalog."""
+    monkeypatch.chdir(tmp_path)
+    cache_file = tmp_path / ".cache" / "overture_release.json"
+    cache_file.parent.mkdir()
+    cache_file.write_text(
+        json.dumps(
+            {
+                "release": "https:/stac.overturemaps.org/2026-08-19.0",
+                "timestamp": datetime.now().isoformat(),
+            }
+        )
+    )
+    catalog = {
+        "links": [
+            {
+                "rel": "child",
+                "title": "Latest Overture Release",
+                "href": "https://stac.overturemaps.org/2026-08-19.0/catalog.json",
+            }
+        ]
+    }
+    with mock.patch.object(downloaders.requests, "get") as mock_get:
+        mock_get.return_value.json.return_value = catalog
+        _, url = downloaders._get_latest_s3_url()
+
+    assert "release/2026-08-19.0/" in url
+    mock_get.assert_called_once()


### PR DESCRIPTION
Replaces #505: the same two commits, now on a branch in this repository so that CI has access to the Codecov token and does not need approval for each run.

Closes #502 and #503.

**Problem observed**

On a fresh `pip install -e .` of `main` (f0c18be) on 2026-09-04, macOS 26.6.2, Python 3.11.15, every run failed twice over:

1. The buildings download:
   ```
   FileNotFoundError: overturemaps-us-west-2/release/https:/stac.overturemaps.org/2026-08-19.0/theme=buildings/type=building/
   ```
   `_get_latest_s3_url` takes `Path(href).parent` of the newest child link in the Overture STAC catalog; those hrefs are absolute URLs now, so the release id came out as `https:/stac.overturemaps.org/2026-08-19.0` and was then cached in `.cache/overture_release.json` for 72 hours.
2. Once past that, `clip_to_catchments`:
   ```
   numba.core.errors.TypingError: ... Cannot determine Numba type of <class 'affine.Affine'>
   ```
   `affine` 3.0 (released 2026-08-08) turned `Affine` from a namedtuple into a plain class, and the `@njit` function `pyflwdir.dem.slope` that `geospatial_utilities` calls with the raster transform can no longer type it. `pyflwdir 0.5.12` has not adapted yet.

Both come from upstream changes in August, so `main` currently fails the notebook runs in CI as well; the last green run on `main` predates them. The two fixes are in one PR because the notebooks need both to get through: with only one of them CI fails on the other error (that is what #505 and #506 showed separately).

**Changes**

- Extract the Overture release id with a regex (`\d{4}-\d{2}-\d{2}\.\d+`) from the href instead of taking the parent path; the catalog ordering logic is unchanged. A cached entry whose `release` is not a well-formed id is ignored, so working directories that already hold the malformed cache recover on their own. Two mocked tests in `tests/test_prepare_data.py`, no network access.
- Pin `affine<3` in `pyproject.toml`. The alternative is to pass a plain tuple to `pyflwdir.dem.slope` in `geospatial_utilities` (the numba kernel only indexes `transform[0]`, `[4]` and `[5]`); happy to switch to that if you prefer a code change over a pin.

**Checks**

`pytest tests/test_prepare_data.py -k s3_url` (2 passed), the repository's pre-commit hooks, and with both changes the documentation's Andorra bounding box builds end to end again with `affine 2.4.0`.
